### PR TITLE
Fixed wrong shader compilation in persistent buffer example

### DIFF
--- a/src/PersistentMappedBuffer.cpp
+++ b/src/PersistentMappedBuffer.cpp
@@ -52,7 +52,7 @@ GLuint CompileShaders(const GLchar** vertexShaderSource, const GLchar** fragment
   //Compile fragment shader
   GLuint fragmentShader( glCreateShader( GL_FRAGMENT_SHADER ) );
   glShaderSource( fragmentShader, 1, fragmentShaderSource, NULL );
-  glCompileShader( vertexShader );
+  glCompileShader( fragmentShader );
   
   //Link vertex and fragment shader together
   GLuint program( glCreateProgram() );


### PR DESCRIPTION
Title says it all.

Code on [site](https://ferransole.wordpress.com/2014/06/08/persistent-mapped-buffers/#more-132) is all right though.

Otherwise great examples!